### PR TITLE
Ajuste na validação de Goias

### DIFF
--- a/src/Util/Validador/Goias.php
+++ b/src/Util/Validador/Goias.php
@@ -54,15 +54,14 @@ class Goias implements ValidadorInteface
 
         $resto = $soma % 11;
 
-        $dig = 11 - $resto;
-
-        if ($dig >= 10) {
-            if ($dig == 11 && '10103105' <= $corpo && $corpo <= '10119997') {
+        if ($resto == 0 || $resto == 1) {
+            if ($resto == 1 && $corpo >= '10103105' && $corpo <= '10119997'){
                 $dig = 1;
             } else {
                 $dig = 0;
             }
-
+        } else {
+            $dig = 11 - $resto;
         }
         return $dig == $inscricao_estadual[$posicao];
     }


### PR DESCRIPTION
Fala Thiagocfn, tudo bem?
Excelente repositório.

Fiz uma pequena alteração na validação de Goias para reconhecer a seguinte IE '10.115.360-0'. (que não passava na validação anterior)
Reescrevi a validação com base na regra e observações disponíveis no http://www.sintegra.gov.br/Cad_Estados/cad_GO.html

A diferença maior é que somente Resto diferente de 0 ou 1 que o digito é calculado com 11-Resto.

Favor validar/conferir e não esquece de confirmar o composer também.

Abraço, Até.